### PR TITLE
Fix: Resolve issue with webhook endpoint not hitting

### DIFF
--- a/app/webhook/clerk/route.ts
+++ b/app/webhook/clerk/route.ts
@@ -21,6 +21,6 @@ export async function POST(request: Request) {
 }
 
 export async function GET() {
-  console.clear();
+  console.log("Endpoint Hit");
   return NextResponse.json({ message: "Why are you here?" });
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ import { authMiddleware } from "@clerk/nextjs";
 const HOME_ROUTE = "/home";
 
 export default authMiddleware({
-  publicRoutes: ["/api/clerk", HOME_ROUTE],
+  publicRoutes: ["/webhook/clerk", HOME_ROUTE],
 
   afterAuth(auth, req) {
     // If the user is not signed-in, send them to HOME_ROUTE


### PR DESCRIPTION
# Important fix for webhook event

Fixed an issue where the webhook endpoint (used when a new user is created) was not being triggered. Turns out that the API endpoint `/api/clerk` was not being hit for unknown reasons. To resolve this, the endpoint was renamed to `/webhook/clerk`, which successfully triggered the webhook and allowed new user profiles to be created for storing transaction data. Further investigation into this issue is planned to prevent similar occurrences in the future.